### PR TITLE
pmem: add missing functions to windows build file

### DIFF
--- a/win/libpmem/libpmem.def
+++ b/win/libpmem/libpmem.def
@@ -37,6 +37,8 @@ LIBRARY libpmem
 VERSION 1.0
 
 EXPORTS
+	pmem_unmap
+	posix_fallocate
 	pmem_map
 	pmem_is_pmem
 	pmem_persist


### PR DESCRIPTION
the .def file was missing 2 functions
